### PR TITLE
remove vscode directory and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.exclude": {
-        "**/*.css": true
-    }
-}


### PR DESCRIPTION
The vscode directory is unnecessary and only used by the local development workspace. It doesn't need to be in the public repo